### PR TITLE
Fixed navbar links target

### DIFF
--- a/style.css
+++ b/style.css
@@ -171,7 +171,7 @@ body{
 
 /* all similar styling */
 section{
-    padding: 60px 0;
+    padding: 120px 0;
     padding-bottom: 300px;
 }
 .about, .services, .skills, .contact, footer{


### PR DESCRIPTION
The issue was, when you click on any link in the navbar when it takes to the target div, the topmost part of the section is hidden due to the navbar. 
**Ex:** If you click about in navbar, it takes to about section but the heading is hidden due to navbar. We feel lost after clicking any target link in navbar because we don't know where we are.
I've solved that by doubling the padding-top for sections. This makes it clear which section we are, increases the usability. Eventhough code change is minor, I feel it increases the usability.

**Before**
![image](https://user-images.githubusercontent.com/56996463/137119003-7cfe379c-3ab0-4528-bcfc-c6701354ee6f.png)

**After**
![image](https://user-images.githubusercontent.com/56996463/137119315-300479d4-29b7-432d-904a-b0f1ce5b0038.png)

Hope you find this useful!